### PR TITLE
Replace in-memory run queue with durable run leasing

### DIFF
--- a/command_center_test.go
+++ b/command_center_test.go
@@ -50,6 +50,28 @@ func installFakeTool(t *testing.T, dir string, name string) {
 	}
 }
 
+func readSSEEvent(reader *bufio.Reader) (string, error) {
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "event: ") {
+			eventType := strings.TrimSpace(strings.TrimPrefix(trimmed, "event: "))
+			for {
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					return "", err
+				}
+				if strings.TrimSpace(line) == "" {
+					return eventType, nil
+				}
+			}
+		}
+	}
+}
+
 func TestServiceModeRootRedirectsToLogin(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	t.Setenv("NWA_ADMIN_PASSWORD", "adminpass")
@@ -315,12 +337,95 @@ func TestPlatformEngagementJSONResources(t *testing.T) {
 		t.Fatalf("events content type = %q, want text/event-stream", contentType)
 	}
 	reader := bufio.NewReader(eventResponse.Body)
-	line, err := reader.ReadString('\n')
+	eventType, err := readSSEEvent(reader)
 	if err != nil {
-		t.Fatalf("read event line error = %v", err)
+		t.Fatalf("readSSEEvent() error = %v", err)
 	}
-	if got := strings.TrimSpace(line); got != "event: engagement.snapshot" {
-		t.Fatalf("event line = %q, want engagement.snapshot", got)
+	if eventType != "engagement.snapshot" {
+		t.Fatalf("event type = %q, want engagement.snapshot", eventType)
+	}
+}
+
+func TestPlatformEngagementEventsPushOnJobUpdates(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Setenv("NWA_ADMIN_PASSWORD", "adminpass")
+	app, err := newApplicationWithConfig(applicationConfig{
+		DBDSN:           filepath.Join(t.TempDir(), "service.sqlite"),
+		DataDir:         filepath.Join(t.TempDir(), "data"),
+		WorkspaceTarget: "engagement-alpha",
+	}, logger)
+	if err != nil {
+		t.Fatalf("newApplicationWithConfig() error = %v", err)
+	}
+
+	handler, err := app.routes()
+	if err != nil {
+		t.Fatalf("routes() error = %v", err)
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error = %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	loginResponse, err := client.PostForm(server.URL+"/login", url.Values{
+		"login":    {"admin"},
+		"password": {"adminpass"},
+	})
+	if err != nil {
+		t.Fatalf("login request error = %v", err)
+	}
+	_ = loginResponse.Body.Close()
+
+	workspace := app.workspace
+	engagement, err := app.platform.store.engagementByWorkspaceID(workspace.id)
+	if err != nil {
+		t.Fatalf("engagementByWorkspaceID() error = %v", err)
+	}
+	workspace.plugins.mu.Lock()
+	workspace.plugins.plugins["fake-manual"] = fakePlugin{id: "fake-manual", label: "Fake Manual"}
+	workspace.plugins.mu.Unlock()
+
+	eventResponse, err := client.Get(server.URL + "/api/v1/engagements/" + engagement.Slug + "/events")
+	if err != nil {
+		t.Fatalf("GET events error = %v", err)
+	}
+	defer eventResponse.Body.Close()
+
+	reader := bufio.NewReader(eventResponse.Body)
+	if _, err := readSSEEvent(reader); err != nil {
+		t.Fatalf("initial readSSEEvent() error = %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := readSSEEvent(reader)
+		result <- err
+	}()
+
+	if _, err := workspace.plugins.submitDetailed(pluginSubmission{
+		PluginID:   "fake-manual",
+		RawTargets: []string{"198.51.100.25"},
+		Summary:    "Manual follow-up",
+	}); err != nil {
+		t.Fatalf("submitDetailed() error = %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("second readSSEEvent() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected job update to trigger SSE event without polling delay")
 	}
 }
 

--- a/platform_api_engagement.go
+++ b/platform_api_engagement.go
@@ -29,10 +29,11 @@ func (app *application) handleEngagementSummaryJSON(writer http.ResponseWriter, 
 }
 
 func (app *application) handleEngagementScopeJSON(writer http.ResponseWriter, request *http.Request) {
-	context, ok := app.requireAPIEngagementContext(writer, request, false)
+	context, ok := app.requireAPIEngagementContext(writer, request, true)
 	if !ok {
 		return
 	}
+	_ = app.platform.syncEngagement(context.Engagement)
 	stats, err := app.platform.store.engagementStats(context.Engagement.ID)
 	if err != nil {
 		http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -149,10 +150,11 @@ func (app *application) handleEngagementSourcesJSON(writer http.ResponseWriter, 
 }
 
 func (app *application) handleEngagementRunsJSON(writer http.ResponseWriter, request *http.Request) {
-	context, ok := app.requireAPIEngagementContext(writer, request, false)
+	context, ok := app.requireAPIEngagementContext(writer, request, true)
 	if !ok {
 		return
 	}
+	_ = app.platform.syncEngagement(context.Engagement)
 	items, err := app.platform.store.listEngagementRuns(context.Engagement.ID, 0)
 	if err != nil {
 		http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -166,6 +168,7 @@ func (app *application) handleEngagementCampaignsJSON(writer http.ResponseWriter
 	if !ok {
 		return
 	}
+	_ = app.platform.syncEngagement(context.Engagement)
 	stats, err := app.platform.store.engagementStats(context.Engagement.ID)
 	if err != nil {
 		http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -247,7 +250,7 @@ func (app *application) handleEngagementSettingsJSON(writer http.ResponseWriter,
 }
 
 func (app *application) handleEngagementEventsSSE(writer http.ResponseWriter, request *http.Request) {
-	context, ok := app.requireAPIEngagementContext(writer, request, false)
+	context, ok := app.requireAPIEngagementContext(writer, request, true)
 	if !ok {
 		return
 	}
@@ -259,8 +262,13 @@ func (app *application) handleEngagementEventsSSE(writer http.ResponseWriter, re
 	writer.Header().Set("Content-Type", "text/event-stream")
 	writer.Header().Set("Cache-Control", "no-cache")
 	writer.Header().Set("Connection", "keep-alive")
+	events, cancel := context.Workspace.plugins.subscribe()
+	defer cancel()
 
 	send := func() bool {
+		if app.platform != nil {
+			_ = app.platform.syncEngagement(context.Engagement)
+		}
 		stats, err := app.platform.store.engagementStats(context.Engagement.ID)
 		if err != nil {
 			http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -286,16 +294,22 @@ func (app *application) handleEngagementEventsSSE(writer http.ResponseWriter, re
 		return
 	}
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
+	keepAlive := time.NewTicker(30 * time.Second)
+	defer keepAlive.Stop()
 	for {
 		select {
 		case <-request.Context().Done():
 			return
-		case <-ticker.C:
+		case <-events:
+			for len(events) > 0 {
+				<-events
+			}
 			if !send() {
 				return
 			}
+		case <-keepAlive.C:
+			_, _ = writer.Write([]byte(": keep-alive\n\n"))
+			flusher.Flush()
 		}
 	}
 }

--- a/plugins.go
+++ b/plugins.go
@@ -28,6 +28,12 @@ const (
 	jobFailed    = "failed"
 )
 
+const (
+	jobLeaseDuration      = 30 * time.Second
+	jobLeaseRenewInterval = 10 * time.Second
+	jobWorkerPollInterval = 250 * time.Millisecond
+)
+
 type jobArtifact struct {
 	Label   string `json:"label"`
 	RelPath string `json:"rel_path"`
@@ -54,8 +60,11 @@ type pluginJob struct {
 	WorkerZone     string            `json:"worker_zone,omitempty"`
 	Options        map[string]string `json:"options,omitempty"`
 	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at,omitempty"`
 	StartedAt      string            `json:"started_at,omitempty"`
 	FinishedAt     string            `json:"finished_at,omitempty"`
+	LeaseOwner     string            `json:"lease_owner,omitempty"`
+	LeaseExpiresAt string            `json:"lease_expires_at,omitempty"`
 	Summary        string            `json:"summary,omitempty"`
 	Error          string            `json:"error,omitempty"`
 	Artifacts      []jobArtifact     `json:"artifacts,omitempty"`
@@ -92,11 +101,13 @@ type pluginManager struct {
 	logger           *slog.Logger
 	store            workspaceStateStore
 	workspace        *workspace
-	queue            chan string
 	mu               sync.RWMutex
 	plugins          map[string]plugin
 	dynamicPluginIDs map[string]struct{}
 	jobs             map[string]*pluginJob
+	subsMu           sync.Mutex
+	subscribers      map[int]chan struct{}
+	nextSubscriberID int
 }
 
 type pluginSubmission struct {
@@ -286,7 +297,6 @@ func newPluginManager(store workspaceStateStore, workspace *workspace, logger *s
 		logger:    logger,
 		store:     store,
 		workspace: workspace,
-		queue:     make(chan string, 64),
 		plugins: map[string]plugin{
 			"burp-connector":    &burpConnectorPlugin{},
 			"dnsx":              &dnsxPlugin{},
@@ -304,6 +314,7 @@ func newPluginManager(store workspaceStateStore, workspace *workspace, logger *s
 		},
 		dynamicPluginIDs: map[string]struct{}{},
 		jobs:             map[string]*pluginJob{},
+		subscribers:      map[int]chan struct{}{},
 	}
 	if err := manager.syncDynamicPlugins(); err != nil {
 		return nil, err
@@ -315,7 +326,7 @@ func newPluginManager(store workspaceStateStore, workspace *workspace, logger *s
 
 	workers := minInt(maxInt(runtime.GOMAXPROCS(0)/2, 1), 4)
 	for index := 0; index < workers; index++ {
-		go manager.worker()
+		go manager.worker(index + 1)
 	}
 	return manager, nil
 }
@@ -358,26 +369,12 @@ func (m *pluginManager) load() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, job := range jobs {
-		if job.Status == jobRunning || job.Status == jobQueued {
-			job.Status = jobFailed
-			job.Error = "server restarted before job completion"
-			job.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+		if strings.TrimSpace(job.UpdatedAt) == "" {
+			job.UpdatedAt = chooseString(job.FinishedAt, job.StartedAt, job.CreatedAt)
 		}
 		m.jobs[job.ID] = job
 	}
-	return m.persistLocked()
-}
-
-func (m *pluginManager) persistLocked() error {
-	jobs := make([]*pluginJob, 0, len(m.jobs))
-	for _, job := range m.jobs {
-		jobs = append(jobs, cloneJob(job))
-	}
-	sort.SliceStable(jobs, func(left, right int) bool {
-		return jobs[left].CreatedAt < jobs[right].CreatedAt
-	})
-
-	return m.store.saveJobs(jobs)
+	return nil
 }
 
 func (m *pluginManager) submit(pluginID string, rawTargets []string, hostIPs []string, summary string, options map[string]string) (PluginJobView, error) {
@@ -443,16 +440,16 @@ func (m *pluginManager) submitDetailed(input pluginSubmission) (PluginJobView, e
 		WorkerZone:    strings.TrimSpace(input.WorkerZone),
 		Options:       cloneStringMap(input.Options),
 		CreatedAt:     now,
+		UpdatedAt:     now,
 		Summary:       "Queued for execution",
 	}
 
 	m.jobs[job.ID] = job
-	if err := m.persistLocked(); err != nil {
+	if err := m.store.upsertJob(job); err != nil {
 		delete(m.jobs, job.ID)
 		return PluginJobView{}, err
 	}
-
-	m.queue <- job.ID
+	m.publish()
 	return jobView(job), nil
 }
 
@@ -482,26 +479,54 @@ func (m *pluginManager) definition(pluginID string) (PluginDefinitionView, bool)
 	return normalizedPluginDefinition(plugin.Definition()), true
 }
 
-func (m *pluginManager) worker() {
-	for jobID := range m.queue {
-		m.execute(jobID)
+func (m *pluginManager) worker(index int) {
+	workerID := fmt.Sprintf("central-local-%d", index)
+	for {
+		jobs, err := m.store.claimQueuedJobs(workerID, 1, time.Now().UTC().Add(jobLeaseDuration).Format(time.RFC3339))
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Warn("claim queued jobs", "worker", workerID, "error", err)
+			}
+			time.Sleep(jobWorkerPollInterval)
+			continue
+		}
+		if len(jobs) == 0 {
+			time.Sleep(jobWorkerPollInterval)
+			continue
+		}
+		for _, job := range jobs {
+			m.mu.Lock()
+			m.jobs[job.ID] = cloneJob(job)
+			m.mu.Unlock()
+			m.publish()
+			m.execute(workerID, job)
+		}
 	}
 }
 
-func (m *pluginManager) execute(jobID string) {
-	m.mu.Lock()
-	job := m.jobs[jobID]
-	if job == nil || job.Status != jobQueued {
-		m.mu.Unlock()
+func (m *pluginManager) execute(workerID string, job *pluginJob) {
+	if job == nil {
 		return
 	}
-	plugin := m.plugins[job.PluginID]
-	job.Status = jobRunning
-	job.StartedAt = time.Now().UTC().Format(time.RFC3339)
-	job.Summary = "Launching " + plugin.Definition().Label
-	_ = m.persistLocked()
-	jobCopy := cloneJob(job)
-	m.mu.Unlock()
+	plugin, ok := m.pluginByID(job.PluginID)
+	if !ok {
+		m.finish(job.ID, PluginRunResult{}, fmt.Errorf("unknown plugin %q", job.PluginID))
+		return
+	}
+	if err := m.updateJob(job.ID, func(item *pluginJob) {
+		item.Status = jobRunning
+		item.WorkerID = workerID
+		item.LeaseOwner = workerID
+		item.LeaseExpiresAt = time.Now().UTC().Add(jobLeaseDuration).Format(time.RFC3339)
+		item.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		item.Summary = "Launching " + plugin.Definition().Label
+	}); err != nil && m.logger != nil {
+		m.logger.Warn("mark job running", "job", job.ID, "error", err)
+	}
+	jobCopy, ok := m.jobByID(job.ID)
+	if !ok {
+		return
+	}
 
 	workDir := filepath.Join(m.workspace.artifactRoot(), jobCopy.ID)
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
@@ -512,6 +537,9 @@ func (m *pluginManager) execute(jobID string) {
 	hosts := m.workspace.targetHosts(jobCopy.HostIPs)
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
 	defer cancel()
+	stopLease := make(chan struct{})
+	defer close(stopLease)
+	go m.renewLease(ctx, stopLease, workerID, jobCopy.ID)
 
 	result, err := plugin.Run(ctx, pluginRunRequest{
 		Job:             jobCopy,
@@ -535,45 +563,41 @@ func (m *pluginManager) updateJobSummary(jobID string, summary string) {
 	if summary == "" {
 		return
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	job := m.jobs[jobID]
-	if job == nil || job.Status != jobRunning {
-		return
-	}
-	job.Summary = summary
-	_ = m.persistLocked()
+	_ = m.updateJob(jobID, func(job *pluginJob) {
+		if job.Status != jobRunning {
+			return
+		}
+		job.Summary = summary
+		job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		job.LeaseExpiresAt = time.Now().UTC().Add(jobLeaseDuration).Format(time.RFC3339)
+	})
 }
 
 func (m *pluginManager) finish(jobID string, result PluginRunResult, runErr error) {
-	m.mu.Lock()
-
-	job := m.jobs[jobID]
-	if job == nil {
-		m.mu.Unlock()
-		return
-	}
-
-	job.Artifacts = append([]jobArtifact(nil), result.Artifacts...)
-	job.Findings = result.Findings
-	job.DerivedTargets = append([]string(nil), result.DerivedTargets...)
-	job.Summary = result.Summary
-	job.FinishedAt = time.Now().UTC().Format(time.RFC3339)
-
-	if runErr != nil {
-		job.Status = jobFailed
-		job.Error = runErr.Error()
-	} else {
-		job.Status = jobCompleted
-		job.Error = ""
-	}
-
-	_ = m.persistLocked()
-	m.mu.Unlock()
+	_ = m.updateJob(jobID, func(job *pluginJob) {
+		job.Artifacts = append([]jobArtifact(nil), result.Artifacts...)
+		job.Findings = result.Findings
+		job.DerivedTargets = append([]string(nil), result.DerivedTargets...)
+		job.Summary = result.Summary
+		job.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+		job.UpdatedAt = job.FinishedAt
+		job.LeaseOwner = ""
+		job.LeaseExpiresAt = ""
+		if runErr != nil {
+			job.Status = jobFailed
+			job.Error = runErr.Error()
+			if strings.TrimSpace(job.Summary) == "" {
+				job.Summary = "Run failed"
+			}
+		} else {
+			job.Status = jobCompleted
+			job.Error = ""
+		}
+	})
 	if m.workspace != nil {
-		m.workspace.syncCommandCenterJob(job)
+		if job, ok := m.jobByID(jobID); ok {
+			m.workspace.syncCommandCenterJob(job)
+		}
 		m.workspace.refreshHistory()
 	}
 }
@@ -786,6 +810,84 @@ func (m *pluginManager) jobByID(id string) (*pluginJob, bool) {
 		return nil, false
 	}
 	return cloneJob(job), true
+}
+
+func (m *pluginManager) subscribe() (<-chan struct{}, func()) {
+	m.subsMu.Lock()
+	defer m.subsMu.Unlock()
+	id := m.nextSubscriberID
+	m.nextSubscriberID++
+	channel := make(chan struct{}, 1)
+	m.subscribers[id] = channel
+	cancel := func() {
+		m.subsMu.Lock()
+		defer m.subsMu.Unlock()
+		if current, ok := m.subscribers[id]; ok {
+			delete(m.subscribers, id)
+			close(current)
+		}
+	}
+	return channel, cancel
+}
+
+func (m *pluginManager) publish() {
+	m.subsMu.Lock()
+	defer m.subsMu.Unlock()
+	for _, subscriber := range m.subscribers {
+		select {
+		case subscriber <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (m *pluginManager) updateJob(jobID string, mutate func(*pluginJob)) error {
+	m.mu.Lock()
+	job := m.jobs[jobID]
+	if job == nil {
+		m.mu.Unlock()
+		return nil
+	}
+	mutate(job)
+	copy := cloneJob(job)
+	m.mu.Unlock()
+
+	if err := m.store.upsertJob(copy); err != nil {
+		return err
+	}
+	m.publish()
+	return nil
+}
+
+func (m *pluginManager) renewLease(ctx context.Context, stop <-chan struct{}, workerID string, jobID string) {
+	ticker := time.NewTicker(jobLeaseRenewInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stop:
+			return
+		case <-ticker.C:
+			_ = m.updateJob(jobID, func(job *pluginJob) {
+				if job.Status != jobRunning || job.LeaseOwner != workerID {
+					return
+				}
+				job.LeaseExpiresAt = time.Now().UTC().Add(jobLeaseDuration).Format(time.RFC3339)
+				job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			})
+		}
+	}
+}
+
+func (m *pluginManager) pluginByID(pluginID string) (plugin, bool) {
+	if err := m.syncDynamicPlugins(); err != nil && m.logger != nil {
+		m.logger.Warn("sync custom tools", "error", err)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	item, ok := m.plugins[strings.TrimSpace(pluginID)]
+	return item, ok
 }
 
 type nucleiPlugin struct{}
@@ -1416,6 +1518,31 @@ func jobStatusTone(status string) string {
 	}
 }
 
+func jobClaimable(job *pluginJob, now string) bool {
+	if job == nil {
+		return false
+	}
+	switch job.Status {
+	case jobQueued:
+		return true
+	case jobRunning:
+		if strings.TrimSpace(job.LeaseExpiresAt) == "" {
+			return true
+		}
+		expiresAt, err := time.Parse(time.RFC3339, job.LeaseExpiresAt)
+		if err != nil {
+			return true
+		}
+		current, err := time.Parse(time.RFC3339, now)
+		if err != nil {
+			return true
+		}
+		return !expiresAt.After(current)
+	default:
+		return false
+	}
+}
+
 func cloneJob(job *pluginJob) *pluginJob {
 	if job == nil {
 		return nil
@@ -1426,6 +1553,7 @@ func cloneJob(job *pluginJob) *pluginJob {
 	copy.Capabilities = append([]string(nil), job.Capabilities...)
 	copy.Options = cloneStringMap(job.Options)
 	copy.Artifacts = append([]jobArtifact(nil), job.Artifacts...)
+	copy.DerivedTargets = append([]string(nil), job.DerivedTargets...)
 	return &copy
 }
 

--- a/service_store.go
+++ b/service_store.go
@@ -644,6 +644,109 @@ func (s *serviceWorkspaceStore) loadJobs() ([]*pluginJob, error) {
 	return loadServiceJSONRows[*pluginJob](s, "jobs")
 }
 
+func (s *serviceWorkspaceStore) upsertJob(job *pluginJob) error {
+	if job == nil {
+		return errors.New("nil job")
+	}
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+	query := `INSERT INTO jobs(workspace_id, id, created_at, payload_json) VALUES(` + s.service.placeholder(1) + `, ` + s.service.placeholder(2) + `, ` + s.service.placeholder(3) + `, ` + s.service.placeholder(4) + `)`
+	if s.service.driver == "pgx" {
+		query += ` ON CONFLICT(workspace_id, id) DO UPDATE SET created_at=EXCLUDED.created_at, payload_json=EXCLUDED.payload_json`
+	} else {
+		query += ` ON CONFLICT(workspace_id, id) DO UPDATE SET created_at=excluded.created_at, payload_json=excluded.payload_json`
+	}
+	_, err = s.service.db.Exec(query, s.workspaceID, job.ID, job.CreatedAt, string(payload))
+	return err
+}
+
+func (s *serviceWorkspaceStore) claimQueuedJobs(workerID string, limit int, leaseUntil string) ([]*pluginJob, error) {
+	tx, err := s.service.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	query := `SELECT id, payload_json FROM jobs WHERE workspace_id = ` + s.service.placeholder(1) + ` ORDER BY created_at ASC`
+	rows, err := tx.Query(query, s.workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	type jobRow struct {
+		id      string
+		payload string
+	}
+	jobRows := make([]jobRow, 0)
+	for rows.Next() {
+		var row jobRow
+		if err := rows.Scan(&row.id, &row.payload); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		jobRows = append(jobRows, row)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	claimed := make([]*pluginJob, 0, maxInt(limit, 1))
+	for _, row := range jobRows {
+		if limit > 0 && len(claimed) >= limit {
+			break
+		}
+
+		var job pluginJob
+		if err := json.Unmarshal([]byte(row.payload), &job); err != nil {
+			return nil, err
+		}
+		if !jobClaimable(&job, now) {
+			continue
+		}
+
+		job.Status = jobRunning
+		job.WorkerMode = chooseString(strings.TrimSpace(job.WorkerMode), "central")
+		job.WorkerID = chooseString(strings.TrimSpace(job.WorkerID), workerID)
+		job.LeaseOwner = workerID
+		job.LeaseExpiresAt = leaseUntil
+		job.UpdatedAt = now
+		if strings.TrimSpace(job.StartedAt) == "" {
+			job.StartedAt = now
+		}
+
+		newPayload, marshalErr := json.Marshal(&job)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		updateQuery := `UPDATE jobs SET payload_json = ` + s.service.placeholder(1) + ` WHERE workspace_id = ` + s.service.placeholder(2) + ` AND id = ` + s.service.placeholder(3) + ` AND payload_json = ` + s.service.placeholder(4)
+		result, execErr := tx.Exec(updateQuery, string(newPayload), s.workspaceID, row.id, row.payload)
+		if execErr != nil {
+			return nil, execErr
+		}
+		affected, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return nil, rowsErr
+		}
+		if affected == 0 {
+			continue
+		}
+		claimed = append(claimed, cloneJob(&job))
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return claimed, nil
+}
+
 func (s *serviceWorkspaceStore) saveJobs(jobs []*pluginJob) error {
 	tx, err := s.service.db.Begin()
 	if err != nil {

--- a/workspace_persistence.go
+++ b/workspace_persistence.go
@@ -8,6 +8,8 @@ type workspaceStateStore interface {
 	appendEvent(event workspaceEvent) error
 	loadJobs() ([]*pluginJob, error)
 	saveJobs(jobs []*pluginJob) error
+	upsertJob(job *pluginJob) error
+	claimQueuedJobs(workerID string, limit int, leaseUntil string) ([]*pluginJob, error)
 	loadPreferences() (workspacePreferences, error)
 	savePreferences(preferences workspacePreferences) error
 	toolCommandTemplate(pluginID string) (string, error)

--- a/workspace_state_test.go
+++ b/workspace_state_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const mergeSnapshotFixture = `<?xml version="1.0"?>
@@ -72,6 +73,48 @@ func TestWorkspaceImportsAndMergesScans(t *testing.T) {
 	}
 	if len(host.SourceScans) != 2 {
 		t.Fatalf("SourceScans = %#v, want 2 entries", host.SourceScans)
+	}
+}
+
+func TestWorkspaceStoreClaimsExpiredRunningJobs(t *testing.T) {
+	store, err := openWorkspaceStore(filepath.Join(t.TempDir(), "workspace.nwa"))
+	if err != nil {
+		t.Fatalf("openWorkspaceStore() error = %v", err)
+	}
+
+	expired := &pluginJob{
+		ID:             "job-expired",
+		PluginID:       "fake",
+		PluginLabel:    "Fake",
+		Status:         jobRunning,
+		TargetSummary:  "1 target",
+		TargetCount:    1,
+		CreatedAt:      time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:      time.Now().UTC().Add(-90 * time.Second).Format(time.RFC3339),
+		StartedAt:      time.Now().UTC().Add(-90 * time.Second).Format(time.RFC3339),
+		LeaseOwner:     "dead-worker",
+		LeaseExpiresAt: time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339),
+		Summary:        "stale run",
+	}
+	if err := store.upsertJob(expired); err != nil {
+		t.Fatalf("upsertJob() error = %v", err)
+	}
+
+	claimed, err := store.claimQueuedJobs("worker-1", 1, time.Now().UTC().Add(time.Minute).Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("claimQueuedJobs() error = %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("claimQueuedJobs() len = %d, want 1", len(claimed))
+	}
+	if claimed[0].ID != expired.ID {
+		t.Fatalf("claimed job id = %q, want %q", claimed[0].ID, expired.ID)
+	}
+	if claimed[0].LeaseOwner != "worker-1" {
+		t.Fatalf("LeaseOwner = %q, want worker-1", claimed[0].LeaseOwner)
+	}
+	if claimed[0].Status != jobRunning {
+		t.Fatalf("Status = %q, want %q", claimed[0].Status, jobRunning)
 	}
 }
 
@@ -344,12 +387,12 @@ func TestCreateCampaignTargetsDiffScopeAndRecordsLedgerEvent(t *testing.T) {
 		logger:    logger,
 		store:     workspace.store,
 		workspace: workspace,
-		queue:     make(chan string, 8),
 		plugins: map[string]plugin{
 			"nmap-enrich": &nmapEnrichmentPlugin{},
 			"nuclei":      &nucleiPlugin{},
 		},
-		jobs: map[string]*pluginJob{},
+		jobs:        map[string]*pluginJob{},
+		subscribers: map[int]chan struct{}{},
 	}
 
 	checkpoints := workspace.currentHistory().meta()

--- a/workspace_store.go
+++ b/workspace_store.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -357,6 +358,106 @@ func (s *workspaceStore) appendEvent(event workspaceEvent) error {
 
 func (s *workspaceStore) loadJobs() ([]*pluginJob, error) {
 	return loadJSONRows[*pluginJob](s.db, `SELECT payload_json FROM jobs ORDER BY created_at ASC`)
+}
+
+func (s *workspaceStore) upsertJob(job *pluginJob) error {
+	if job == nil {
+		return errors.New("nil job")
+	}
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO jobs(id, created_at, payload_json) VALUES(?, ?, ?) ON CONFLICT(id) DO UPDATE SET created_at=excluded.created_at, payload_json=excluded.payload_json`,
+		job.ID,
+		job.CreatedAt,
+		string(payload),
+	)
+	return err
+}
+
+func (s *workspaceStore) claimQueuedJobs(workerID string, limit int, leaseUntil string) ([]*pluginJob, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rows, err := tx.Query(`SELECT id, payload_json FROM jobs ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, err
+	}
+	type jobRow struct {
+		id      string
+		payload string
+	}
+	jobRows := make([]jobRow, 0)
+	for rows.Next() {
+		var row jobRow
+		if err := rows.Scan(&row.id, &row.payload); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		jobRows = append(jobRows, row)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	claimed := make([]*pluginJob, 0, maxInt(limit, 1))
+	for _, row := range jobRows {
+		if limit > 0 && len(claimed) >= limit {
+			break
+		}
+
+		var job pluginJob
+		if err := json.Unmarshal([]byte(row.payload), &job); err != nil {
+			return nil, err
+		}
+		if !jobClaimable(&job, now) {
+			continue
+		}
+
+		job.Status = jobRunning
+		job.WorkerMode = chooseString(strings.TrimSpace(job.WorkerMode), "central")
+		job.WorkerID = chooseString(strings.TrimSpace(job.WorkerID), workerID)
+		job.LeaseOwner = workerID
+		job.LeaseExpiresAt = leaseUntil
+		job.UpdatedAt = now
+		if strings.TrimSpace(job.StartedAt) == "" {
+			job.StartedAt = now
+		}
+
+		newPayload, marshalErr := json.Marshal(&job)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		result, execErr := tx.Exec(`UPDATE jobs SET payload_json = ? WHERE id = ? AND payload_json = ?`, string(newPayload), row.id, row.payload)
+		if execErr != nil {
+			return nil, execErr
+		}
+		affected, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return nil, rowsErr
+		}
+		if affected == 0 {
+			continue
+		}
+		claimed = append(claimed, cloneJob(&job))
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return claimed, nil
 }
 
 func (s *workspaceStore) loadPreferences() (workspacePreferences, error) {


### PR DESCRIPTION
## Summary
- replace the in-memory job channel with durable per-job persistence and lease-based claiming
- publish engagement SSE updates from real job changes instead of a polling ticker
- add regressions for expired lease reclaiming and event-driven engagement updates

## Testing
- ./scripts/validate-local.sh
- smoke tested local service mode on :8125 for /login, /healthz, /api/v1/engagements, and /api/v1/engagements/engagement-alpha/events

Closes #3